### PR TITLE
refactor(404): :sparkles: cambiar enlaces a rutas limpias y habilitar SPA con 404.html

### DIFF
--- a/src/js/cargar_sedes.js
+++ b/src/js/cargar_sedes.js
@@ -26,7 +26,7 @@ fetch("./data/tableros_completo.json")
 
       // Configuración del link
       a.className = "links";
-      a.href = `tablero.html?sede=${encodeURIComponent(sede)}`;
+      a.href = `./${encodeURIComponent(sede)}`;   //a.href = `tablero.html?sede=${encodeURIComponent(sede)}`;
       a.target = "_blank";
       a.rel = "noopener noreferrer";
 


### PR DESCRIPTION


- Modificado `cargar_sedes.js` para generar enlaces como `./SEDE` en vez de `tablero.html?sede=SEDE`. 
- Implementado router SPA en `404.html` para detectar la sede desde la URL y cargar `tablero.html` dinámicamente. 
- Permite acceder directamente a rutas como `/qrtableros/MUNRO` sin parámetros de query. 
- Mejora UX y SEO al mantener URLs limpias.  

GitHub Pages ahora usa 404.html como router.